### PR TITLE
[19.0][FIX] connector: adapt tests to Acme Corporation demo data

### DIFF
--- a/component_event/components/event.py
+++ b/component_event/components/event.py
@@ -111,7 +111,6 @@ import operator
 from collections import defaultdict
 from functools import wraps
 
-# pylint: disable=W7950
 from odoo.addons.component.core import AbstractComponent, Component
 
 _logger = logging.getLogger(__name__)

--- a/connector/components/synchronizer.py
+++ b/connector/components/synchronizer.py
@@ -22,7 +22,6 @@ from contextlib import contextmanager
 import psycopg2
 
 import odoo
-from odoo import _
 
 from odoo.addons.component.core import AbstractComponent
 
@@ -191,14 +190,16 @@ class GenericExporter(AbstractComponent):
         if self.external_id:
             record = self._update_data(map_record, fields=fields)
             if not record:
-                return _("Nothing to export.")
+                return self.env._("Nothing to export.")
             self._update(record)
         else:
             record = self._create_data(map_record, fields=fields)
             if not record:
-                return _("Nothing to export.")
+                return self.env._("Nothing to export.")
             self.external_id = self._create(record)
-        return _("Record exported with ID %s on Backend.") % self.external_id
+        return self.env._(
+            "Record exported with ID %(ext_id)s on Backend.", ext_id=self.external_id
+        )
 
     def _after_export(self):
         """Can do several actions after exporting a record on the backend"""

--- a/connector/models/queue_job.py
+++ b/connector/models/queue_job.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Camptocamp SA
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
-from odoo import _, models
+from odoo import models
 
 
 class QueueJob(models.Model):
@@ -25,7 +25,7 @@ class QueueJob(models.Model):
             # not handled
             return None
         action = {
-            "name": _("Related Record"),
+            "name": self.env._("Related Record"),
             "type": "ir.actions.act_window",
             "view_type": "form",
             "view_mode": "form",

--- a/connector/tests/test_mapper.py
+++ b/connector/tests/test_mapper.py
@@ -682,7 +682,7 @@ class TestMapperRecordsets(TransactionComponentRegistryCase):
         partner = self.env.ref("base.res_partner_address_4")
         mapper = self.comp_registry["my.mapper"](self.work)
         map_record = mapper.map_record(partner)
-        expected = {"parent_name": "Deco Addict"}
+        expected = {"parent_name": "Acme Corporation"}
         self.assertEqual(map_record.values(), expected)
         self.assertEqual(map_record.values(for_create=True), expected)
 

--- a/connector/tests/test_mapper.py
+++ b/connector/tests/test_mapper.py
@@ -113,7 +113,6 @@ class TestMapper(TransactionComponentRegistryCase):
             def name(self):
                 pass
 
-        # pylint: disable=R7980
         class FryMapperInherit(Component):
             _inherit = "fry.mapper"
 


### PR DESCRIPTION
regarding odoo standard FIX: replace "Deco Addict" with "Acme Corporation"

A company that happens to be named "Deco Addict" has complained some of our users thought they had business with them due to test and demo data containing that name.

It will now be named Acme Corporation.